### PR TITLE
Update URL to CONTRIBUTING.md in pull_request_template.md

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -6,7 +6,7 @@
 
 **Notes to PR author**
 
-⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/code-of-conduct/blob/main/CONTRIBUTING.md).
+⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/.github/blob/main/CONTRIBUTING.md).
 
 **Notes to reviewers**
 


### PR DESCRIPTION
This URL previously pointed to the now archived aligent/code-of-conduct repo. The CONTRIBUTING.md file now lives alongside pull_request_template.md in the aligent/.github repo.

**Description of the proposed changes**

**Screenshots (if applicable)**

**Other solutions considered (if any)**

**Notes to PR author**

⚠️ Please make sure the changes adhere to the guidelines mentioned in our [contribution guide](https://github.com/aligent/code-of-conduct/blob/main/CONTRIBUTING.md).

**Notes to reviewers**

ℹ️ When you've finished leaving feedback, please add a final comment to the PR tagging the author, letting them know that you have finished leaving feedback

